### PR TITLE
fix(ui): restore export/import buttons lost in sprint 8 template rewrite

### DIFF
--- a/web/app/plugins/pb-split-guide/templates/admin-my-tutorials.php
+++ b/web/app/plugins/pb-split-guide/templates/admin-my-tutorials.php
@@ -16,6 +16,8 @@ $current_tab      = isset($current_tab) ? $current_tab : 'recent';
 $is_admin         = isset($is_admin) ? (bool) $is_admin : false;
 $transfer_enabled = isset($transfer_enabled) ? (bool) $transfer_enabled : false;
 $base_url         = admin_url('admin.php?page=pbsg-my-tutorials');
+$export_nonce     = wp_create_nonce('pbsg_export_import');
+$import_nonce     = wp_create_nonce('pbsg_export_import');
 ?>
 
 <div class="wrap pbsg-admin-tutorials-page">
@@ -39,6 +41,19 @@ $base_url         = admin_url('admin.php?page=pbsg-my-tutorials');
         My Tutorials
       </a>
     <?php endif; ?>
+  </div>
+
+  <?php /* ── Import panel ───────────────────────────────────────────── */ ?>
+  <div id="pbsg-import-panel" style="margin-bottom:20px; max-width:520px; background:#fff; border:1px solid #dcdcde; border-radius:6px; padding:18px 20px;">
+    <h2 style="margin-top:0; font-size:15px;">Import Tutorial</h2>
+    <p style="color:#50575e; margin-bottom:12px; font-size:13px;">
+      Upload a <code>.json</code> export file from another Guide on the Side server.
+    </p>
+    <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
+      <input type="file" id="pbsg-import-file" accept=".json" />
+      <button type="button" class="button button-primary" id="pbsg-import-btn">Import</button>
+    </div>
+    <p id="pbsg-import-status" style="margin:10px 0 0; display:none;"></p>
   </div>
 
   <?php if (empty($tutorials)) : ?>
@@ -191,6 +206,16 @@ $base_url         = admin_url('admin.php?page=pbsg-my-tutorials');
                   Transfer
                 </button>
               <?php endif; ?>
+
+              <?php /* Export: plain form POST → AJAX handler streams file download */ ?>
+              <form method="post"
+                    action="<?php echo esc_url(admin_url('admin-ajax.php')); ?>"
+                    style="display:inline;">
+                <input type="hidden" name="action"  value="pbsg_export_tutorial" />
+                <input type="hidden" name="nonce"   value="<?php echo esc_attr($export_nonce); ?>" />
+                <input type="hidden" name="post_id" value="<?php echo esc_attr($item['id']); ?>" />
+                <button type="submit" class="button">Export</button>
+              </form>
             </div>
           </div>
         </div>
@@ -199,3 +224,67 @@ $base_url         = admin_url('admin.php?page=pbsg-my-tutorials');
 
   <?php endif; ?>
 </div>
+
+<script>
+( function( $ ) {
+  var ajaxUrl     = <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>;
+  var importNonce = <?php echo wp_json_encode( $import_nonce ); ?>;
+
+  $( '#pbsg-import-btn' ).on( 'click', function() {
+    var file    = $( '#pbsg-import-file' ).prop( 'files' )[0];
+    var $status = $( '#pbsg-import-status' );
+
+    $status.hide().removeClass( 'notice-success notice-error' );
+
+    if ( ! file ) {
+      $status
+        .addClass( 'notice notice-error inline' )
+        .html( '<p>Please choose a <code>.json</code> export file first.</p>' )
+        .show();
+      return;
+    }
+
+    var fd = new FormData();
+    fd.append( 'action', 'pbsg_import_tutorial' );
+    fd.append( 'nonce', importNonce );
+    fd.append( 'pbsg_import_file', file );
+
+    var $btn = $( this ).prop( 'disabled', true ).text( 'Importing\u2026' );
+
+    $.ajax( {
+      url:         ajaxUrl,
+      type:        'POST',
+      data:        fd,
+      processData: false,
+      contentType: false,
+    } )
+    .done( function( res ) {
+      if ( res && res.success ) {
+        $status
+          .addClass( 'notice notice-success inline' )
+          .html(
+            '<p>Tutorial <strong>' + $( '<span>' ).text( res.data.title ).html() + '</strong> imported successfully. ' +
+            '<a href="' + $( '<span>' ).text( res.data.edit_url ).html() + '">Edit it now.</a></p>'
+          )
+          .show();
+        $( '#pbsg-import-file' ).val( '' );
+      } else {
+        var msg = ( res && res.data && res.data.message ) ? res.data.message : 'Import failed.';
+        $status
+          .addClass( 'notice notice-error inline' )
+          .html( '<p>' + $( '<span>' ).text( msg ).html() + '</p>' )
+          .show();
+      }
+    } )
+    .fail( function() {
+      $status
+        .addClass( 'notice notice-error inline' )
+        .html( '<p>Request failed. Please try again.</p>' )
+        .show();
+    } )
+    .always( function() {
+      $btn.prop( 'disabled', false ).text( 'Import' );
+    } );
+  } );
+} )( jQuery );
+</script>


### PR DESCRIPTION
## Description
Restores the Export and Import tutorial UI that was present in Sprint 7 but accidentally dropped when admin-my-tutorials.php was rewritten in commit 4903854 (tabs + transfer UI overhaul). The backend AJAX handlers (class-pbsg-export-import.php) were never removed — only the template buttons were lost.

## Related Issue
N/A - Discovered during final sprint demo prep

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Style/UI change (formatting, CSS, no code change)
- [ ] Refactor (no functional changes)
- [ ] Test update (adding or updating tests)
- [ ] Configuration change
- [ ] Security fix

## Changes Made
- Added `$export_nonce` and `$import_nonce` generation at top of admin-my-tutorials.php
- Restored Import panel above the tutorials grid (file picker + Import button + status message area)
- Restored Export form button per tutorial card (plain POST to `pbsg_export_tutorial` AJAX handler — streams .json download)
- Restored Import AJAX JavaScript (FormData upload to `pbsg_import_tutorial`, success/error feedback)

## Screenshots
N/A - Restoring previously working UI

## Testing Checklist
- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] All existing tests pass (`npm test`)
- [ ] I have tested on multiple browsers - N/A, restoring existing UI
- [ ] I have tested on tablet viewport - N/A, restoring existing UI

> Note: Export/Import was verified working in Sprint 7 (commit c235882). Backend handlers unchanged — UI restoration only.

## Accessibility Checklist
- [x] Keyboard navigation works correctly — file input and buttons are native elements
- [ ] Screen reader testing completed
- [x] Color contrast meets WCAG 2.1 AA standards — uses standard WordPress .button classes
- [x] Focus indicators are visible — inherited from WP admin styles
- [ ] ARIA labels added where needed
- [ ] No accessibility errors in automated testing (axe/WAVE)

## Documentation Checklist
- [ ] README updated (if needed)
- [x] Code comments added for complex logic — export form has inline comment explaining POST→stream pattern
- [ ] API documentation updated (if applicable)
- [ ] User guide updated (if applicable)

## Pre-Merge Checklist
- [x] Branch is up to date with `main`
- [x] No merge conflicts
- [x] Code follows project coding standards
- [x] No console errors or warnings
- [x] No commented-out code (unless explained)

## Additional Notes
Root cause: 4903854 rewrote the My Tutorials template to add tabs and transfer UI but did not carry forward the export/import panel. Discovered during final sprint demo prep via live site testing.

This fix targets `main` directly since the staging server runs `main`.

## Reviewer Notes
<!-- For reviewers to add notes during review. -->